### PR TITLE
Fix memory leak. Subscribe on key changes only when we need it

### DIFF
--- a/src/swsssdk/interface.py
+++ b/src/swsssdk/interface.py
@@ -234,7 +234,7 @@ class DBInterface(object):
         logger.debug("Subscribe to keyspace notification")
         client = self.redis_clients[db_name]
         pubsub = client.pubsub()
-        pubsub.psubscribe(self.KEYSPACE_PATTERN) # FIXME: subscribe to specific pattern
+        pubsub.psubscribe(self.KEYSPACE_PATTERN)
         self.keyspace_notification_channels[db_name] = pubsub
 
     def _unsubscribe_keyspace_notification(self, db_name):

--- a/src/swsssdk/interface.py
+++ b/src/swsssdk/interface.py
@@ -280,7 +280,7 @@ class DBInterface(object):
         client = self.redis_clients[db_name]
         val = client.hget(_hash, key)
         if not val:
-            message = "Key '{}' unavailable in database '{}' - table '{}'".format(key, _hash, db_name)
+            message = "Key '{}' field '{}' unavailable in database '{}'".format(_hash, key, db_name)
             logger.warning(message)
             raise UnavailableDataError(message, key)
         else:
@@ -298,7 +298,7 @@ class DBInterface(object):
         client = self.redis_clients[db_name]
         table = client.hgetall(_hash)
         if not table:
-            message = "Table '{}' does not exist in database '{}'".format(_hash, db_name)
+            message = "Key '{}' unavailable in database '{}'".format(_hash, db_name)
             logger.warning(message)
             raise UnavailableDataError(message, _hash)
         else:

--- a/src/swsssdk/interface.py
+++ b/src/swsssdk/interface.py
@@ -237,7 +237,7 @@ class DBInterface(object):
         """
         Unsubscribe the chosent client from keyspace event notifications
         """
-        if db_name in inst.keyspace_notification_channels:
+        if db_name in self.keyspace_notification_channels:
             logger.debug("Unsubscribe from keyspace notification")
             self.keyspace_notification_channels[db_name].close()
             del self.keyspace_notification_channels[db_name]

--- a/src/swsssdk/interface.py
+++ b/src/swsssdk/interface.py
@@ -43,10 +43,10 @@ def blockable(f):
                     if db_name in inst.keyspace_notification_channels:
                         result = inst._unavailable_data_handler(db_name, e.data)
                         if result:
-                            continue
+                            continue # received updates, try to read data again
                         else:
-                            raise # No updates
-                    else:
+                            raise    # No updates was received. Raise exception
+                    else: # Subscribe to updates and try it again (avoiding race condition)
                         inst._subscribe_keyspace_notification(db_name)
                 else:
                     return None

--- a/src/swsssdk/interface.py
+++ b/src/swsssdk/interface.py
@@ -282,7 +282,7 @@ class DBInterface(object):
         if not val:
             message = "Key '{}' field '{}' unavailable in database '{}'".format(_hash, key, db_name)
             logger.warning(message)
-            raise UnavailableDataError(message, key)
+            raise UnavailableDataError(message, _hash)
         else:
             # redis only supports strings. if any item is set to string 'None', cast it back to the appropriate type.
             return None if val == b'None' else val

--- a/src/swsssdk/interface.py
+++ b/src/swsssdk/interface.py
@@ -45,6 +45,7 @@ def blockable(f):
                         if result:
                             continue # received updates, try to read data again
                         else:
+                            inst._unsubscribe_keyspace_notification(db_name)
                             raise    # No updates was received. Raise exception
                     else: # Subscribe to updates and try it again (avoiding race condition)
                         inst._subscribe_keyspace_notification(db_name)


### PR DESCRIPTION
Previously database connector subscribed on key notifications, but didn't read messages from publisher until there was no any issue with reading data values. So output queues for clients which use this library was getting bigger and bigger until redis closed data connection.
With this patch I subscribe on key changes only when we waiting for data.
It works in following way:
1. Getting no data exception.
2. Subscribe to key updates
3. Retry request
4. if getting the error again, blocking and waiting for updates.
5. if there're updates, retry request
6. if there're no updates reraise exception
7. after this unsubscribe from key updates
8. and return the data to requestor.

Previously there was error, if there no data, forever, the request would have been performed for ever. 
