### PR TITLE
Support hierarchical keys

### DIFF
--- a/src/swsssdk/configdb.py
+++ b/src/swsssdk/configdb.py
@@ -40,7 +40,7 @@ class ConfigDBConnector(SonicV2Connector):
             pubsub.psubscribe(pattern)
             for item in pubsub.listen():
                 if item['type'] == 'pmessage':
-                    key = item['channel'].split('|', 1)[1]
+                    key = item['channel'].split(':', 1)[1]
                     if key == self.INIT_INDICATOR:
                         initialized = client.get(self.INIT_INDICATOR)
                         if initialized:

--- a/src/swsssdk/configdb.py
+++ b/src/swsssdk/configdb.py
@@ -125,13 +125,18 @@ class ConfigDBConnector(SonicV2Connector):
 
     @staticmethod
     def serialize_key(key):
-        string_types = str if sys.version_info[0] == 3 else basestring
-        return key if isinstance(key, string_types) else '|'.join(key)
+        if type(key) is tuple:
+            return '|'.join(key)
+        else:
+            return key
 
     @staticmethod
     def deserialize_key(key):
         tokens = key.split('|')
-        return tuple(tokens) if len(tokens) > 1 else tokens[0]
+        if len(tokens) > 1:
+            return tuple(tokens)
+        else:
+            return key
 
     def set_entry(self, table, key, data):
         """Write a table entry to config db.


### PR DESCRIPTION
1. Use `|` instead of `:` for separator in redis key, and support hierarchical multiple keys.
2. Support object with no attribute (`data == {}`) with a `"NULL": "NULL"` placeholder. 
3. `set_entry` now support delete entry with `data == None`.