### PR TITLE
Add support to remove the key of table entry

### DIFF
--- a/src/swsssdk/configdb.py
+++ b/src/swsssdk/configdb.py
@@ -113,9 +113,9 @@ class ConfigDBConnector(SonicV2Connector):
 
     def __typed_to_raw(self, typed_data):
         if typed_data == None:
-            return None
+            return None, None
         elif typed_data == {}:
-            return { "NULL": "NULL" }
+            return { "NULL": "NULL" }, None
         raw_data = {}
         del_data = []
         for key in typed_data:

--- a/src/swsssdk/configdb.py
+++ b/src/swsssdk/configdb.py
@@ -117,13 +117,16 @@ class ConfigDBConnector(SonicV2Connector):
         elif typed_data == {}:
             return { "NULL": "NULL" }
         raw_data = {}
+        del_data = []
         for key in typed_data:
             value = typed_data[key]
             if type(value) is list:
                 raw_data[key+'@'] = ','.join(value)
+            elif value is None:
+                del_data.append(key)
             else:
                 raw_data[key] = value
-        return raw_data
+        return raw_data, del_data
 
     @staticmethod
     def serialize_key(key):
@@ -148,6 +151,7 @@ class ConfigDBConnector(SonicV2Connector):
             data: Table row data in a form of dictionary {'column_key': 'value', ...}.
                   Pass {} as data will create an entry with no column if not already existed.
                   Pass None as data will delete the entry.
+                  Pass {'column_key': None, ...} as data will delete the key which value is None.
         """
         key = self.serialize_key(key)
         client = self.redis_clients[self.CONFIG_DB]
@@ -155,7 +159,11 @@ class ConfigDBConnector(SonicV2Connector):
         if data == None:
             client.delete(_hash)
         else:
-            client.hmset(_hash, self.__typed_to_raw(data))
+            raw_data, del_data = self.__typed_to_raw(data)
+            if del_data:
+                client.hdel(_hash, *del_data)
+            if raw_data:
+                client.hmset(_hash, raw_data)
 
     def get_entry(self, table, key):
         """Read a table entry from config db.


### PR DESCRIPTION
The class ConfigDBConnector has no method to remove the column_key of table entry.  To support it, the method "set_entry" is modified to delete the column_key which value is None.