### PR TITLE
[interface]: Extend the max data wait time to 60s

### DIFF
--- a/src/swsssdk/interface.py
+++ b/src/swsssdk/interface.py
@@ -111,7 +111,7 @@ class DBInterface(object):
     Time to wait for any given message to arrive via pub-sub.
     """
 
-    PUB_SUB_MAXIMUM_DATA_WAIT = 30.0  # seconds
+    PUB_SUB_MAXIMUM_DATA_WAIT = 60.0  # seconds
     """
     Maximum allowable time to wait on a specific pub-sub notification.
     """


### PR DESCRIPTION
- This is only a workaround solution. The next step is to
  remove the hardcoded time frame so that it won't crash
  even if the swss is not running.