### PR TITLE
[configdb] fix bug of leaving unwanted columns in a hash

### DIFF
--- a/src/swsssdk/configdb.py
+++ b/src/swsssdk/configdb.py
@@ -155,7 +155,12 @@ class ConfigDBConnector(SonicV2Connector):
         if data == None:
             client.delete(_hash)
         else:
+            original = self.get_entry(table, key)
             client.hmset(_hash, self.__typed_to_raw(data))
+            for k in [ k for k in original.keys() if k not in data.keys() ]:
+                if type(original[k]) == list:
+                    k = k + '@'
+                client.hdel(_hash, self.serialize_key(k))
 
     def get_entry(self, table, key):
         """Read a table entry from config db.


### PR DESCRIPTION
Current implementation doesn't remove unwanted columes with set_entry
like below.

```
>>> set_entry('table', 'key', {'key1': 'value1', 'key2': 'value2'})
>>> set_entry('table', 'key', {'key1': 'value3'})
>>> get_entry('table', 'key')
{'key1': 'value3', 'key2': 'value2'}
```

This commit fix this bug.

Signed-off-by: Wataru Ishida <ishida.wataru@lab.ntt.co.jp>