### PR TITLE
[configdb]: Fixed a bug that leads to the emerging of records with "None" value in redis-db

### DIFF
--- a/src/swsssdk/configdb.py
+++ b/src/swsssdk/configdb.py
@@ -134,10 +134,11 @@ class ConfigDBConnector(SonicV2Connector):
         raw_data = {}
         for key in typed_data:
             value = typed_data[key]
-            if type(value) is list:
-                raw_data[key+'@'] = ','.join(value)
-            else:
-                raw_data[key] = value
+            if value is not None:
+                if type(value) is list:
+                    raw_data[key+'@'] = ','.join(value)
+                else:
+                    raw_data[key] = value
         return raw_data
 
     @staticmethod


### PR DESCRIPTION
What I did:
Fixed a bug that leads to the emerging of records with "None" value in redis-db
Particularly, bgp_asn = "None" inside the DEVICE_METADATA|localhost entry
leads bgp daemon to crash

How to verify it:
Load a minigraph without BGP settings. Check DEVICE_METADATA|localhost in redis-db. You mustn't see bgp_asn field.
Or try to add to the config_db.json any other configuration field with the value "null" and check if it has appeared in redis-db.

Signed-off-by: Denis Maslov <Denis.Maslov@cavium.com>