### PR TITLE
[DBInterface]add publish interface for DBInterface

### DIFF
--- a/src/swsssdk/interface.py
+++ b/src/swsssdk/interface.py
@@ -254,6 +254,13 @@ class DBInterface(object):
         """
         return self.redis_clients[db_name]
 
+    def publish(self, db_name, channel, message):
+        """
+        Publish message via the channel
+        """
+        client  = self.redis_clients[db_name]
+        return client.publish(channel, message)
+
     @blockable
     def keys(self, db_name, pattern='*'):
         """


### PR DESCRIPTION
to implement a clear fdb cli,  need to send notifications from sonic-utilities to syncd via some channel ASIC_DB, so add an publish interface for the DBInterface.

cli design doc see [https://github.com/Azure/SONiC/wiki/SONiC-Clear-FDB-CLI-Design](url)  