### PR TITLE
Get Vlan Id from BVID object

### DIFF
--- a/src/swsssdk/port_util.py
+++ b/src/swsssdk/port_util.py
@@ -69,3 +69,14 @@ def get_bridge_port_map(db):
 
     return if_br_oid_map
 
+def get_vlan_id_from_bvid(db, bvid):
+    """
+        Get the Vlan Id from Bridge Vlan Object
+    """
+    db.connect('ASIC_DB')
+    vlan_obj = db.keys('ASIC_DB', "ASIC_STATE:SAI_OBJECT_TYPE_VLAN:" + bvid)
+    vlan_entry = db.get_all('ASIC_DB', vlan_obj[0], blocking=True)
+    vlan_id = vlan_entry[b"SAI_VLAN_ATTR_VLAN_ID"]
+
+    return vlan_id
+


### PR DESCRIPTION
With _bvid_, the Vlan id is a attribute in SAI_OBJECT_TYPE_VLAN. The API is to return the Vlan Id given a bvid. 