### PR TITLE
[port_util] Do not use Enum, for python2 compatibility

### DIFF
--- a/src/swsssdk/port_util.py
+++ b/src/swsssdk/port_util.py
@@ -3,7 +3,6 @@ Bridge/Port mapping utility library.
 """
 import swsssdk
 import re
-from enum import Enum
 
 
 SONIC_ETHERNET_RE_PATTERN = "^Ethernet(\d+)$"
@@ -11,7 +10,7 @@ SONIC_PORTCHANNEL_RE_PATTERN = "^PortChannel(\d+)$"
 SONIC_MGMT_PORT_RE_PATTERN = "^eth(\d+)$"
 
 
-class BaseIdx(int, Enum):
+class BaseIdx:
     ethernet_base_idx = 1
     portchannel_base_idx = 1000
     mgmt_port_base_idx = 10000


### PR DESCRIPTION
Fixes issue https://github.com/Azure/SONiC/issues/254

- Avoid import error on python2
- Keep the class with named constants for all the places it is already used 

Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>