### PR TITLE
Force key/value convertion to str before send to redis lib

### DIFF
--- a/src/swsssdk/configdb.py
+++ b/src/swsssdk/configdb.py
@@ -137,7 +137,7 @@ class ConfigDBConnector(SonicV2Connector):
             if type(value) is list:
                 raw_data[key+'@'] = ','.join(value)
             else:
-                raw_data[key] = value
+                raw_data[key] = str(value)
         return raw_data
 
     @staticmethod
@@ -145,7 +145,7 @@ class ConfigDBConnector(SonicV2Connector):
         if type(key) is tuple:
             return ConfigDBConnector.KEY_SEPARATOR.join(key)
         else:
-            return key
+            return str(key)
 
     @staticmethod
     def deserialize_key(key):


### PR DESCRIPTION
Py-redis library starting from 3.00 introduce a behavior change that if objects other than str to be passed as argument to redis, they will not be converted to string, instead an exception will be raised. This breaks the compatibility with our library. This change is to force string conversion in our side to fix the issue.