### PR TITLE
Fix redis-py version to 2.10.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 dependencies = [
-    'redis>=2.10.1',
+    'redis==2.10.6',
 ]
 
 high_performance_deps = [


### PR DESCRIPTION
So we use specific stable version instead of latest one.
This is to partially fix https://github.com/Azure/sonic-utilities/issues/379