### PR TITLE
[configdb]: Fixed TypeErrorException when get_config with python3 #44

### DIFF
--- a/src/swsssdk/configdb.py
+++ b/src/swsssdk/configdb.py
@@ -280,6 +280,8 @@ class ConfigDBConnector(SonicV2Connector):
         keys = client.keys('*')
         data = {}
         for key in keys:
+            if PY3K:
+                key = key.decode('utf-8')
             try:
                 (table_name, row) = key.split(self.TABLE_NAME_SEPARATOR, 1)
                 entry = self.__raw_to_typed(client.hgetall(key))


### PR DESCRIPTION
commit 9b078292ff8018b7006507b921209d0eb3d03722 (HEAD -> TypeErrorWithPy3k, origin/TypeErrorWithPy3k)
Author: madhu Pal <madhupa@aviznetworks.com>
Date:   Fri Jan 18 05:37:29 2019 +0000

    [configdb]: Fixed TypeErrorException when get_config with python3 #44

**What I did**
Fixed TypeError Exception in configdb.py/get_config() API
**How I did**
Fixed by adding PY3K check.
**How to Verify**
root@sonic:~# python3
Python 3.5.3 (default, Sep 27 2018, 17:25:39)
[GCC 6.3.0 20170516] on linux
Type "help", "copyright", "credits" or "license" for more information.

import swsssdk
db = swsssdk.ConfigDBConnector()
db.connect()
cfg = db.get_config()
Traceback (most recent call last):
File "", line 1, in 
File "/usr/local/lib/python3.5/dist-packages/swsssdk-2.0.1-py3.5.egg/swsssdk/configdb.py", line 284, in get_config
(table_name, row) = key.split(self.TABLE_NAME_SEPARATOR, 1)
TypeError: a bytes-like object is required, not 'str'

