### PR TITLE
[configdb.py] Fixed __raw_to_typed() api to return correct typed obje…

### DIFF
--- a/src/swsssdk/configdb.py
+++ b/src/swsssdk/configdb.py
@@ -109,7 +109,7 @@ class ConfigDBConnector(SonicV2Connector):
 
             # "NULL:NULL" is used as a placeholder for objects with no attributes
             if key == "NULL":
-                pass
+                typed_data = { "NULL": "NULL" }
             # A column key with ending '@' is used to mark list-typed table items
             # TODO: Replace this with a schema-based typing mechanism.
             elif key.endswith("@"):


### PR DESCRIPTION
…ct when redis key is NULL(#277)

Signed-off-by: madhu Pal <madhupa@aviznetworks.com>

**What I did** 
Fixed __raw_to_typed() api to return correct typed object when redis key is NULL.
**How I did**
As we store "NULL:NULL" as a placeholder for objects with no attributes,  the __raw_to_typed() returns None, which causes get_entry() returns None for objects exists with no attributes. 

To fix this issue - added code in __raw_to_typed() to return typed_data = {"NULL":"NULL"} when Key = NULL


