### PR TITLE
[multi-DB] Part 4: add sonic-db-cli to replace redis-cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     package_dir={'swsssdk': 'src/swsssdk'},
     packages=['swsssdk'],
     package_data={'swsssdk': ['config/*.json']},
+    scripts=['src/swsssdk/scripts/sonic-db-cli'],
     license='Apache 2.0',
     author='SONiC Team',
     author_email='linuxnetdev@microsoft.com',

--- a/src/swsssdk/dbconnector.py
+++ b/src/swsssdk/dbconnector.py
@@ -103,7 +103,7 @@ class SonicDBConfig(object):
         return SonicDBConfig._sonic_db_config["DATABASES"][db_name]["separator"]
 
 class SonicV2Connector(DBInterface):
-    def __init__(self, use_unix_socket_path=True, **kwargs):
+    def __init__(self, use_unix_socket_path=False, **kwargs):
         super(SonicV2Connector, self).__init__(**kwargs)
         self.use_unix_socket_path = use_unix_socket_path
         for db_name in self.get_db_list():

--- a/src/swsssdk/dbconnector.py
+++ b/src/swsssdk/dbconnector.py
@@ -111,7 +111,7 @@ class SonicV2Connector(DBInterface):
             setattr(self, db_name, db_name)
 
     def connect(self, db_name, retry_on=True):
-        if self.use_unix_socket_path == False:
+        if self.use_unix_socket_path:
             self.redis_kwargs["unix_socket_path"] = self.get_db_socket(db_name)
             self.redis_kwargs["host"] = None
             self.redis_kwargs["port"] = None

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -1,0 +1,35 @@
+#!/usr/bin/python
+import os
+import sys
+import swsssdk
+import logging
+import subprocess
+import redis
+from redis import RedisError
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.NullHandler())
+
+DOCKER_EXEC_FLAGS = "i"
+
+# Determine whether stdout is on a terminal
+if os.isatty(1):
+    DOCKER_EXEC_FLAGS += "t"
+
+if len(sys.argv) < 3:
+    msg = "More than three arguments are required. 'usage: sonic-db-cli dbname rediscommands'"
+    print >> sys.stderr, msg
+    logger.error(msg)
+else:
+    try:
+        dbid = swsssdk.SonicDBConfig.get_dbid(sys.argv[1])
+        dbhostname = swsssdk.SonicDBConfig.get_hostname(sys.argv[1])
+        dbport = swsssdk.SonicDBConfig.get_port(sys.argv[1])
+    except RuntimeError:
+        msg = "Invalid database name input : '{}'".format(sys.argv[1])
+        print >> sys.stderr, msg
+        logger.error(msg)
+    else:
+        client = redis.StrictRedis(db=dbid, host=dbhostname, port=dbport)
+        print client.execute_command(" ".join(sys.argv[2:]))

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -11,25 +11,19 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 logger.addHandler(logging.NullHandler())
 
-DOCKER_EXEC_FLAGS = "i"
-
-# Determine whether stdout is on a terminal
-if os.isatty(1):
-    DOCKER_EXEC_FLAGS += "t"
-
 if len(sys.argv) < 3:
     msg = "More than three arguments are required. 'usage: sonic-db-cli dbname rediscommands'"
     print >> sys.stderr, msg
     logger.error(msg)
 else:
+    dbname = sys.argv[1]
+    dbconn = swsssdk.SonicV2Connector(use_unix_socket_path=False)
     try:
-        dbid = swsssdk.SonicDBConfig.get_dbid(sys.argv[1])
-        dbhostname = swsssdk.SonicDBConfig.get_hostname(sys.argv[1])
-        dbport = swsssdk.SonicDBConfig.get_port(sys.argv[1])
+        dbconn.connect(dbname)
     except RuntimeError:
         msg = "Invalid database name input : '{}'".format(sys.argv[1])
         print >> sys.stderr, msg
         logger.error(msg)
     else:
-        client = redis.StrictRedis(db=dbid, host=dbhostname, port=dbport)
+        client = dbconn.get_redis_client(dbname)
         print client.execute_command(" ".join(sys.argv[2:]))

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -1,11 +1,7 @@
 #!/usr/bin/python
-import os
 import sys
 import swsssdk
 import logging
-import subprocess
-import redis
-from redis import RedisError
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -7,8 +7,13 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 logger.addHandler(logging.NullHandler())
 
-if len(sys.argv) < 3:
-    msg = "More than three arguments are required. 'usage: sonic-db-cli dbname rediscommands'"
+argc = len(sys.argv)
+if argc == 2 and sys.argv[1] == '-h':
+    print "Example 1: sonic-db-cli CONFIG_DB keys *"
+    print "Example 2: sonic-db-cli APPL_DB HGETALL VLAN_TABLE:Vlan10"
+    print "Example 3: sonic-db-cli APPL_DB HGET VLAN_TABLE:Vlan10 mtu"
+elif argc < 3:
+    msg = "'Usage: sonic-db-cli <db_name> <cmd> [cmd [arg [arg ...]]]'. See 'sonic-db-cli -h' for detail example."
     print >> sys.stderr, msg
     logger.error(msg)
 else:

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -1,11 +1,6 @@
 #!/usr/bin/python
 import sys
 import swsssdk
-import logging
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-logger.addHandler(logging.NullHandler())
 
 argc = len(sys.argv)
 if argc == 2 and sys.argv[1] == '-h':
@@ -13,9 +8,8 @@ if argc == 2 and sys.argv[1] == '-h':
     print "Example 2: sonic-db-cli APPL_DB HGETALL VLAN_TABLE:Vlan10"
     print "Example 3: sonic-db-cli APPL_DB HGET VLAN_TABLE:Vlan10 mtu"
 elif argc < 3:
-    msg = "'Usage: sonic-db-cli <db_name> <cmd> [cmd [arg [arg ...]]]'. See 'sonic-db-cli -h' for detail example."
+    msg = "'Usage: sonic-db-cli <db_name> <cmd> [arg [arg ...]]'. See 'sonic-db-cli -h' for detail examples."
     print >> sys.stderr, msg
-    logger.error(msg)
 else:
     dbname = sys.argv[1]
     dbconn = swsssdk.SonicV2Connector(use_unix_socket_path=False)
@@ -24,7 +18,6 @@ else:
     except RuntimeError:
         msg = "Invalid database name input : '{}'".format(sys.argv[1])
         print >> sys.stderr, msg
-        logger.error(msg)
     else:
         client = dbconn.get_redis_client(dbname)
         print client.execute_command(" ".join(sys.argv[2:]))


### PR DESCRIPTION
* add sonic-db-cli wrapper to replace redis-cli later when applying multiDB
  - sonic-db-cli CONFIG_DB keys *   =   redis-cli -p 6379 -n 4 keys * 
* package in swsssdk, it will be installed in /usr/local/bin/sonic-db-cli when swsssdk pkg is installed 
 - cover both host and docker environment

admin@ASW-7005:~$ sonic-db-cli LOGLEVEL_Dx
More than three arguments are required. 'usage: sonic-db-cli 'dbname' 'redis commands''

admin@ASW-7005:~$ sonic-db-cli LOGLEVEL_DB x
(error) ERR unknown command `x`, with args beginning with: 

admin@ASW-7005:~$ sonic-db-cli LOGLEVEL_DB1 keys *
Invalid database name input : 'LOGLEVEL_DB1'

admin@ASW-7005:~$ sonic-db-cli LOGLEVEL_DB keys *
 1) "SAI_API_IPMC_GROUP:SAI_API_IPMC_GROUP"
 2) "SAI_API_VLAN:SAI_API_VLAN"
 3) "SAI_API_LAG:SAI_API_LAG"
 4) "vxlanmgrd:vxlanmgrd"
 5) "teamsyncd:teamsyncd"
 6) "vlanmgrd:vlanmgrd"



Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com