### PR TITLE
[MultiDB]: update sonic-db-cli output to redis-cli output format

### DIFF
--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -25,9 +25,14 @@ else:
         client = dbconn.get_redis_client(dbname)
         args = sys.argv[2:]
         resp = client.execute_command(*args)
+        """
+        sonic-db-cli output format mimic the non-tty mode output format from redis-cli
+        based on our usage in SONiC, None and list type output from python API needs to be modified
+        with these changes, it is enough for us to mimic redis-cli in SONiC so far since no application uses tty mode redis-cli output
+        """
         if resp is None:
             print ""
-        elif type(resp) is list:
+        elif isinstance(resp, list):
             print " ".join(resp)
         else:
             print resp

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -24,4 +24,10 @@ else:
     else:
         client = dbconn.get_redis_client(dbname)
         args = sys.argv[2:]
-        print client.execute_command(*args)
+        resp = client.execute_command(*args)
+        if resp is None:
+            print ""
+        elif type(resp) is list:
+            print " ".join(resp)
+        else:
+            print resp


### PR DESCRIPTION
* When field value is empty:
    * today redis-cli return "", sonic-db-cli return 'None'
    * some caller check 'None' word since the data may be string 'None' 
    * CHANGES, sonic-db-cli check return type , if it is None, then return "", if not None, return the string (including "None")

* when return value is a list:
    * today redis-cli returns "TB|E1 TB|E2 TB|E3 ..." , sonic-db-cli returns "['TB|E1',  'TB|E2',  'TB|E3'] ..", when list is empty, redis-cli return "" while sonic-db-cli returns [].
    * CHANGES, sonic-db-cli check return type, it it is a list, output all thge element as a joint string.

* So far, only found these two usage is needed to be changed in sonic-db-cli , other redis operation like SET/FLUSH/GET/HGET/KEYS are good and the output are some format after these changes.

Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com