### PR TITLE
[MultiDB]: update sonic-db-cli list output seperator to '\n'

### DIFF
--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -33,6 +33,6 @@ else:
         if resp is None:
             print ""
         elif isinstance(resp, list):
-            print " ".join(resp)
+            print "\n".join(resp)
         else:
             print resp


### PR DESCRIPTION
@qiluo-msft 

* We made a mistake earlier. When we try  `redis-cli keys "XXX"` output earlier, we thought it join KEY by blank, actually it is `\n`. But the output still have issue when KEY contains blank, since for loop in shell script make the KEY contains blank into two parts.

* We should use `\n` to join python list output as well, though there is no effect when shell script iterating each element in a for loop.


```
admin@ASW-7005:~$ echo $(redis-cli -n 4 keys *PortChannel10*)
PortChannel10 Test PORTCHANNEL|PortChannel10 VLAN_MEMBER|Vlan10|PortChannel10 PORTCHANNEL_MEMBER|PortChannel10|Ethernet9
admin@ASW-7005:~$ echo "$(redis-cli -n 4 keys *PortChannel10*)"
PortChannel10 Test
PORTCHANNEL|PortChannel10
VLAN_MEMBER|Vlan10|PortChannel10
PORTCHANNEL_MEMBER|PortChannel10|Ethernet9
admin@ASW-7005:~$ 
admin@ASW-7005:~$ 
admin@ASW-7005:~$ echo $(/etc/sonic/sonic-db-cli CONFIG_DB keys *PortChannel10*)
PortChannel10 Test PORTCHANNEL|PortChannel10 VLAN_MEMBER|Vlan10|PortChannel10 PORTCHANNEL_MEMBER|PortChannel10|Ethernet9
admin@ASW-7005:~$ echo "$(/etc/sonic/sonic-db-cli CONFIG_DB keys *PortChannel10*)"
PortChannel10 Test
PORTCHANNEL|PortChannel10
VLAN_MEMBER|Vlan10|PortChannel10
PORTCHANNEL_MEMBER|PortChannel10|Ethernet9
```

Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com