### PR TITLE
[configdb.py]: Allow deletion of entire table from mod_config API.

### DIFF
--- a/src/swsssdk/configdb.py
+++ b/src/swsssdk/configdb.py
@@ -294,6 +294,9 @@ class ConfigDBConnector(SonicV2Connector):
         """
         for table_name in data:
             table_data = data[table_name]
+            if table_data == None:
+                self.delete_table(table_name)
+                continue
             for key in table_data:
                 self.mod_entry(table_name, key, table_data[key])
 


### PR DESCRIPTION
sonic-cfggen uses mod_config to write to db. mod_config API should allow
deletion of entire table instead of throwing python exception.

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com


Testing: [I tested with YANG model in picture, but that does not matter for this PR]
Before Fix:

```
admin@lnos-x1-a-asw01:~/pc_testing_merge$ cat interface_none.json

{ "INTERFACE": null }

admin@lnos-x1-a-asw01:~/pc_testing_merge$ sudo config load interface_none.json -y

Loaded below Yang Models
['sonic-acl', 'sonic-head', 'sonic-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from interface_none.json
Data Validation successful

Running command: /usr/local/bin/sonic-cfggen -j interface_none.json --write-to-db
Traceback (most recent call last):
File "/usr/local/bin/sonic-cfggen", line 322, in <module>
main()
File "/usr/local/bin/sonic-cfggen", line 311, in main
configdb.mod_config(FormatConverter.output_to_db(sort_data(data)))
File "/usr/local/lib/python2.7/dist-packages/swsssdk/configdb.py", line 299, in mod_config
for key in table_data:
TypeError: 'NoneType' object is not iterable

```

 

After Fix:

admin@lnos-x1-a-asw01:~/pc_testing_merge$ cat interface_none.json

{ "INTERFACE": null }

admin@lnos-x1-a-asw01:~/pc_testing_merge$ sudo config load interface_none.json -y
Loaded below Yang Models
['sonic-acl', 'sonic-head', 'sonic-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from interface_none.json
Data Validation successful
Running command: /usr/local/bin/sonic-cfggen -j interface_none.json --write-to-db