### PR TITLE
Un-revert "read portchannel name from LAG_NAME_MAP_TABLE in COUNTERS_DB"

### DIFF
--- a/src/swsssdk/port_util.py
+++ b/src/swsssdk/port_util.py
@@ -49,6 +49,9 @@ def get_interface_oid_map(db):
     """
     db.connect('COUNTERS_DB')
     if_name_map = db.get_all('COUNTERS_DB', 'COUNTERS_PORT_NAME_MAP', blocking=True)
+    if_lag_name_map = db.get_all('COUNTERS_DB', 'COUNTERS_LAG_NAME_MAP', blocking=True)
+    if_name_map.update(if_lag_name_map)
+
     oid_pfx = len("oid:0x")
     if_name_map = {if_name: sai_oid[oid_pfx:] for if_name, sai_oid in if_name_map.items()}
 


### PR DESCRIPTION
Add Azure/sonic-py-swsssdk#51 back in by reverting Azure/sonic-py-swsssdk#57, in because issues should be addressed by the merge of https://github.com/Azure/sonic-swss/pull/1124