### PR TITLE
[MultiDB] add sonic-db-cli PING all instances support

### DIFF
--- a/src/swsssdk/dbconnector.py
+++ b/src/swsssdk/dbconnector.py
@@ -68,7 +68,7 @@ class SonicDBConfig(object):
         return SonicDBConfig._sonic_db_config["INSTANCES"][inst_name]
 
     @staticmethod
-    def get_instance_list():
+    def get_instancelist():
         if SonicDBConfig._sonic_db_config_init == False:
             SonicDBConfig.load_sonic_db_config()
         return SonicDBConfig._sonic_db_config["INSTANCES"]

--- a/src/swsssdk/dbconnector.py
+++ b/src/swsssdk/dbconnector.py
@@ -68,6 +68,12 @@ class SonicDBConfig(object):
         return SonicDBConfig._sonic_db_config["INSTANCES"][inst_name]
 
     @staticmethod
+    def get_instance_list():
+        if SonicDBConfig._sonic_db_config_init == False:
+            SonicDBConfig.load_sonic_db_config()
+        return SonicDBConfig._sonic_db_config["INSTANCES"]
+
+    @staticmethod
     def get_socket(db_name):
         if SonicDBConfig._sonic_db_config_init == False:
             SonicDBConfig.load_sonic_db_config()

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -24,7 +24,7 @@ def ping_all_instances():
     # ping all redis instances one by one
     p = Pool(len(db_insts))
     rsps =  p.map(ping_single_instance, [v for k, v in db_insts.items()])
-    return 'PONG' if all(rsp == 'PONG' for rsp in rsps) else rsps
+    return 'PONG' if all(rsp == 'PONG' for rsp in rsps) else 'FAILED'
 
 def execute_cmd(dbname, cmd):
     dbconn = swsssdk.SonicV2Connector(use_unix_socket_path=False)

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -2,7 +2,6 @@
 import sys
 import swsssdk
 import redis
-import syslog
 import argparse
 from multiprocessing import Pool
 
@@ -15,12 +14,13 @@ def ping_single_instance(inst_info):
     try:
         rsp = r.ping()
     except redis.exceptions.ConnectionError as e:
-        syslog.syslog(syslog.LOG_ERR, 'ping redis inst failed at host {} port {}'.format(inst_hostname, inst_port))
+        pass
     return 'PONG' if rsp else msg
 
 def ping_all_instances():
     db_insts = swsssdk.SonicDBConfig.get_instancelist()
-    # ping all redis instances one by one
+    # ping all redis instances together
+    # TODO: if one of the ping failed, it could fail quickly and not necessary to wait all other pings
     p = Pool(len(db_insts))
     rsps =  p.map(ping_single_instance, [v for k, v in db_insts.items()])
     msg = []

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -7,34 +7,23 @@ import syslog
 import argparse
 from multiprocessing import Pool
 
-
-def print_examples():
-    print("""
-'Usage: sonic-db-cli [PING | <db_name> <cmd> [arg [arg ...]]]'
-Example 1: sonic-db-cli CONFIG_DB keys *
-Example 2: sonic-db-cli APPL_DB HGETALL VLAN_TABLE:Vlan10
-Example 3: sonic-db-cli APPL_DB HGET VLAN_TABLE:Vlan10 mtu
-Example 4: sonic-db-cli APPL_DB EVAL "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}" 2 k1 k2 v1 v2
-Example 5: sonic-db-cli PING
-""")
-
 def ping_single_instance(inst_info):
     inst_hostname = inst_info['hostname']
     inst_port = inst_info['port']
     r = redis.Redis(host=inst_hostname, port=inst_port)
     rsp = False
-    while not rsp:
-        try:
-            rsp = r.ping()
-        except redis.exceptions.ConnectionError as e:
-            syslog.syslog(syslog.LOG_ERR, 'ping redis inst failed at host {} port {}'.format(inst_hostname, inst_port))
-            time.sleep(1)
+    try:
+        rsp = r.ping()
+    except redis.exceptions.ConnectionError as e:
+        syslog.syslog(syslog.LOG_ERR, 'ping redis inst failed at host {} port {}'.format(inst_hostname, inst_port))
+    return 'PONG' if rsp else e
 
 def ping_all_instances():
     db_insts = swsssdk.SonicDBConfig.get_instancelist()
     # ping all redis instances one by one
-    p = Pool(len(db_insts.keys()))
-    p.map(ping_single_instance, [v for k, v in db_insts.items()])
+    p = Pool(len(db_insts))
+    rsps =  p.map(ping_single_instance, [v for k, v in db_insts.items()])
+    return 'PONG' if all(rsp == 'PONG' for rsp in rsps) else rsps
 
 def execute_cmd(dbname, cmd):
     dbconn = swsssdk.SonicV2Connector(use_unix_socket_path=False)
@@ -60,8 +49,16 @@ def execute_cmd(dbname, cmd):
 
 def main():
     parser = argparse.ArgumentParser(description='SONiC DB CLI',
-                         formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('db_or_op', nargs='?', type=str, help='Database name Or Unary operation')
+                                     formatter_class=argparse.RawTextHelpFormatter,
+                                     epilog=
+"""
+Example 1: sonic-db-cli CONFIG_DB keys *
+Example 2: sonic-db-cli APPL_DB HGETALL VLAN_TABLE:Vlan10
+Example 3: sonic-db-cli APPL_DB HGET VLAN_TABLE:Vlan10 mtu
+Example 4: sonic-db-cli APPL_DB EVAL "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}" 2 k1 k2 v1 v2
+Example 5: sonic-db-cli PING
+""")
+    parser.add_argument('db_or_op', type=str, help='Database name Or Unary operation(only PING supported)')
     parser.add_argument('cmd', nargs='*', type=str, help='Command to execute in database')
 
     args = parser.parse_args()
@@ -70,16 +67,14 @@ def main():
         if args.cmd:
             execute_cmd(args.db_or_op, args.cmd)
         elif args.db_or_op == 'PING':
-            ping_all_instances()
+            print ping_all_instances()
 #       TODO next PR will support 'SAVE' and 'FLUSHALL'
 #       elif args.db_or_op == 'SAVE':
 #       elif args.db_or_op == 'FLUSHALL':
         else:
             parser.print_help()
-            print_examples()
     else:
         parser.print_help()
-        print_examples()
 
 if __name__ == "__main__":
     main()

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -2,7 +2,6 @@
 import sys
 import swsssdk
 import redis
-import time
 import syslog
 import argparse
 from multiprocessing import Pool

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -60,7 +60,6 @@ def execute_cmd(dbname, cmd):
 
 def main():
     parser = argparse.ArgumentParser(description='SONiC DB CLI',
-                         version='1.0.0',
                          formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('db_or_op', nargs='?', type=str, help='Database name Or Unary operation')
     parser.add_argument('cmd', nargs='*', type=str, help='Command to execute in database')

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -1,17 +1,43 @@
 #!/usr/bin/python
 import sys
 import swsssdk
+import redis
+import time
+import syslog
 
 argc = len(sys.argv)
-if argc == 2 and sys.argv[1] == '-h':
-    print("""
+if argc == 2:
+    op = sys.argv[1]
+    if op == '-h':
+        print("""
 Example 1: sonic-db-cli CONFIG_DB keys *
 Example 2: sonic-db-cli APPL_DB HGETALL VLAN_TABLE:Vlan10
 Example 3: sonic-db-cli APPL_DB HGET VLAN_TABLE:Vlan10 mtu
 Example 4: sonic-db-cli APPL_DB EVAL "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}" 2 k1 k2 v1 v2
+Example 4: sonic-db-cli PING
 """)
-elif argc < 3:
-    msg = "'Usage: sonic-db-cli <db_name> <cmd> [arg [arg ...]]'. See 'sonic-db-cli -h' for detail examples."
+        sys.exit(0)
+    elif op == 'PING':
+        db_insts = swsssdk.SonicDBConfig.get_instance_list()
+        # ping all redis instances one by one
+        for inst in db_insts:
+            inst_hostname = db_insts[inst]['hostname']
+            inst_port = db_insts[inst]['port']
+            r = redis.Redis(host=inst_hostname, port=inst_port)
+            rsp = False
+            while not rsp:
+                try:
+                    rsp = r.ping()
+                except redis.exceptions.ConnectionError as e:
+                    syslog.syslog(syslog.LOG_ERR, 'ping redis instance {} failed'.format(inst))
+                    time.sleep(1)
+        sys.exit(0)
+#   TODO next PR will support 'SAVE' and 'FLUSHALL'
+#   elif op == 'SAVE':
+#   elif op == 'FLUSHALL':
+
+if argc < 3:
+    msg = "'Usage: sonic-db-cli [PING | <db_name> <cmd> [arg [arg ...]]]'. See 'sonic-db-cli -h' for detail examples."
     print >> sys.stderr, msg
 else:
     dbname = sys.argv[1]

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -4,53 +4,48 @@ import swsssdk
 import redis
 import time
 import syslog
+import argparse
+from multiprocessing import Pool
 
-argc = len(sys.argv)
-if argc == 2:
-    op = sys.argv[1]
-    if op == '-h':
-        print("""
+
+def print_examples():
+    print("""
+'Usage: sonic-db-cli [PING | <db_name> <cmd> [arg [arg ...]]]'
 Example 1: sonic-db-cli CONFIG_DB keys *
 Example 2: sonic-db-cli APPL_DB HGETALL VLAN_TABLE:Vlan10
 Example 3: sonic-db-cli APPL_DB HGET VLAN_TABLE:Vlan10 mtu
 Example 4: sonic-db-cli APPL_DB EVAL "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}" 2 k1 k2 v1 v2
-Example 4: sonic-db-cli PING
+Example 5: sonic-db-cli PING
 """)
-        sys.exit(0)
-    elif op == 'PING':
-        db_insts = swsssdk.SonicDBConfig.get_instance_list()
-        # ping all redis instances one by one
-        for inst in db_insts:
-            inst_hostname = db_insts[inst]['hostname']
-            inst_port = db_insts[inst]['port']
-            r = redis.Redis(host=inst_hostname, port=inst_port)
-            rsp = False
-            while not rsp:
-                try:
-                    rsp = r.ping()
-                except redis.exceptions.ConnectionError as e:
-                    syslog.syslog(syslog.LOG_ERR, 'ping redis instance {} failed'.format(inst))
-                    time.sleep(1)
-        sys.exit(0)
-#   TODO next PR will support 'SAVE' and 'FLUSHALL'
-#   elif op == 'SAVE':
-#   elif op == 'FLUSHALL':
 
-if argc < 3:
-    msg = "'Usage: sonic-db-cli [PING | <db_name> <cmd> [arg [arg ...]]]'. See 'sonic-db-cli -h' for detail examples."
-    print >> sys.stderr, msg
-else:
-    dbname = sys.argv[1]
+def ping_single_instance(inst_info):
+    inst_hostname = inst_info['hostname']
+    inst_port = inst_info['port']
+    r = redis.Redis(host=inst_hostname, port=inst_port)
+    rsp = False
+    while not rsp:
+        try:
+            rsp = r.ping()
+        except redis.exceptions.ConnectionError as e:
+            syslog.syslog(syslog.LOG_ERR, 'ping redis inst failed at host {} port {}'.format(inst_hostname, inst_port))
+            time.sleep(1)
+
+def ping_all_instances():
+    db_insts = swsssdk.SonicDBConfig.get_instancelist()
+    # ping all redis instances one by one
+    p = Pool(len(db_insts.keys()))
+    p.map(ping_single_instance, [v for k, v in db_insts.items()])
+
+def execute_cmd(dbname, cmd):
     dbconn = swsssdk.SonicV2Connector(use_unix_socket_path=False)
     try:
         dbconn.connect(dbname)
     except RuntimeError:
-        msg = "Invalid database name input : '{}'".format(sys.argv[1])
+        msg = "Invalid database name input : '{}'".format(dbname)
         print >> sys.stderr, msg
     else:
         client = dbconn.get_redis_client(dbname)
-        args = sys.argv[2:]
-        resp = client.execute_command(*args)
+        resp = client.execute_command(*cmd)
         """
         sonic-db-cli output format mimic the non-tty mode output format from redis-cli
         based on our usage in SONiC, None and list type output from python API needs to be modified
@@ -62,3 +57,30 @@ else:
             print "\n".join(resp)
         else:
             print resp
+
+def main():
+    parser = argparse.ArgumentParser(description='SONiC DB CLI',
+                         version='1.0.0',
+                         formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('db_or_op', nargs='?', type=str, help='Database name Or Unary operation')
+    parser.add_argument('cmd', nargs='*', type=str, help='Command to execute in database')
+
+    args = parser.parse_args()
+
+    if args.db_or_op:
+        if args.cmd:
+            execute_cmd(args.db_or_op, args.cmd)
+        elif args.db_or_op == 'PING':
+            ping_all_instances()
+#       TODO next PR will support 'SAVE' and 'FLUSHALL'
+#       elif args.db_or_op == 'SAVE':
+#       elif args.db_or_op == 'FLUSHALL':
+        else:
+            parser.print_help()
+            print_examples()
+    else:
+        parser.print_help()
+        print_examples()
+
+if __name__ == "__main__":
+    main()

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -11,11 +11,10 @@ def ping_single_instance(inst_info):
     inst_port = inst_info['port']
     r = redis.Redis(host=inst_hostname, port=inst_port)
     rsp = False
-    msg = 'ping failed at host {} port {}'.format(inst_hostname, inst_port)
+    msg = 'Could not connect to Redis at {}:{}: Connection refused'.format(inst_hostname, inst_port)
     try:
         rsp = r.ping()
     except redis.exceptions.ConnectionError as e:
-        msg = str(e)
         syslog.syslog(syslog.LOG_ERR, 'ping redis inst failed at host {} port {}'.format(inst_hostname, inst_port))
     return 'PONG' if rsp else msg
 
@@ -24,7 +23,16 @@ def ping_all_instances():
     # ping all redis instances one by one
     p = Pool(len(db_insts))
     rsps =  p.map(ping_single_instance, [v for k, v in db_insts.items()])
-    return 'PONG' if all(rsp == 'PONG' for rsp in rsps) else 'FAILED'
+    msg = []
+    for rsp in rsps:
+        if rsp != 'PONG':
+            msg.append(rsp)
+    if msg:
+        print '\n'.join(msg)
+        sys.exit(1)
+    else:
+        print 'PONG'
+        sys.exit(0)
 
 def execute_cmd(dbname, cmd):
     dbconn = swsssdk.SonicV2Connector(use_unix_socket_path=False)
@@ -33,6 +41,7 @@ def execute_cmd(dbname, cmd):
     except RuntimeError:
         msg = "Invalid database name input : '{}'".format(dbname)
         print >> sys.stderr, msg
+        sys.exit(1)
     else:
         client = dbconn.get_redis_client(dbname)
         resp = client.execute_command(*cmd)
@@ -47,6 +56,7 @@ def execute_cmd(dbname, cmd):
             print "\n".join(resp)
         else:
             print resp
+        sys.exit(0)
 
 def main():
     parser = argparse.ArgumentParser(description='SONiC DB CLI',
@@ -68,7 +78,7 @@ Example 5: sonic-db-cli PING
         if args.cmd:
             execute_cmd(args.db_or_op, args.cmd)
         elif args.db_or_op == 'PING':
-            print ping_all_instances()
+            ping_all_instances()
 #       TODO next PR will support 'SAVE' and 'FLUSHALL'
 #       elif args.db_or_op == 'SAVE':
 #       elif args.db_or_op == 'FLUSHALL':

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -11,11 +11,13 @@ def ping_single_instance(inst_info):
     inst_port = inst_info['port']
     r = redis.Redis(host=inst_hostname, port=inst_port)
     rsp = False
+    msg = 'ping failed at host {} port {}'.format(inst_hostname, inst_port)
     try:
         rsp = r.ping()
     except redis.exceptions.ConnectionError as e:
+        msg = str(e)
         syslog.syslog(syslog.LOG_ERR, 'ping redis inst failed at host {} port {}'.format(inst_hostname, inst_port))
-    return 'PONG' if rsp else e
+    return 'PONG' if rsp else msg
 
 def ping_all_instances():
     db_insts = swsssdk.SonicDBConfig.get_instancelist()


### PR DESCRIPTION
* ping pong all redis instances using sonic-db-cli PING
* for the first commit of multiDB changes, we introduced script dockers/docker-database/ping_pong_db_insts to ping pong all redis instances instead of redis-cli ping, at that time , swsssdk lib is not modified to support multiDB.
* another PR will replace script ping_pong_db_insts with sonic-db-cli PING
* another PR will add SAVE and FLUSHALL option for sonic-db-cli as well

Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com