### PR TITLE
Decode byte encoded response from redis before printing

### DIFF
--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -7,6 +7,14 @@ import argparse
 from multiprocessing import Pool
 from functools import partial
 
+def print_response(resp):
+    if resp is None:
+        print()
+    elif isinstance(resp, list):
+        for x in resp: print(x.decode('utf-8') if isinstance(x, bytes) else x)
+    else:
+        print(resp.decode('utf-8') if isinstance(resp, bytes) else resp)
+
 def handle_single_instance(op, use_unix_socket, inst_info):
     inst_hostname = inst_info['hostname']
     if use_unix_socket:
@@ -76,12 +84,7 @@ def execute_cmd(dbname, cmd, namespace, use_unix_socket=False):
         based on our usage in SONiC, None and list type output from python API needs to be modified
         with these changes, it is enough for us to mimic redis-cli in SONiC so far since no application uses tty mode redis-cli output
         """
-        if resp is None:
-            print()
-        elif isinstance(resp, list):
-            print("\n".join(resp))
-        else:
-            print(resp)
+        print_response(resp)
         sys.exit(0)
 
 def main():

--- a/src/swsssdk/scripts/sonic-db-cli
+++ b/src/swsssdk/scripts/sonic-db-cli
@@ -7,14 +7,6 @@ import argparse
 from multiprocessing import Pool
 from functools import partial
 
-def print_response(resp):
-    if resp is None:
-        print()
-    elif isinstance(resp, list):
-        for x in resp: print(x.decode('utf-8') if isinstance(x, bytes) else x)
-    else:
-        print(resp.decode('utf-8') if isinstance(resp, bytes) else resp)
-
 def handle_single_instance(op, use_unix_socket, inst_info):
     inst_hostname = inst_info['hostname']
     if use_unix_socket:
@@ -65,11 +57,11 @@ def handle_all_instances(namespace, op, use_unix_socket=False):
 def execute_cmd(dbname, cmd, namespace, use_unix_socket=False):
     if namespace is None:
         if use_unix_socket:
-            dbconn = swsssdk.SonicV2Connector(use_unix_socket_path=True)
+            dbconn = swsssdk.SonicV2Connector(use_unix_socket_path=True, decode_responses=True)
         else:
-            dbconn = swsssdk.SonicV2Connector(use_unix_socket_path=False)
+            dbconn = swsssdk.SonicV2Connector(use_unix_socket_path=False, decode_responses=True)
     else:
-        dbconn = swsssdk.SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
+        dbconn = swsssdk.SonicV2Connector(use_unix_socket_path=True, namespace=namespace, decode_responses=True)
     try:
         dbconn.connect(dbname)
     except RuntimeError:
@@ -84,7 +76,12 @@ def execute_cmd(dbname, cmd, namespace, use_unix_socket=False):
         based on our usage in SONiC, None and list type output from python API needs to be modified
         with these changes, it is enough for us to mimic redis-cli in SONiC so far since no application uses tty mode redis-cli output
         """
-        print_response(resp)
+        if resp is None:
+            print()
+        elif isinstance(resp, list):
+            print("\n".join(resp))
+        else:
+            print(resp)
         sys.exit(0)
 
 def main():


### PR DESCRIPTION
Fix https://github.com/Azure/sonic-buildimage/issues/4632

In py3, the response from redis connector is encoded as byte array. They
need to be decoded before accessing them as strings.

Use following commands to test

sonic-db-cli CONFIG_DB "keys *"
sonic-db-cli CONFIG_DB "hget PORT|Ethernet0 admin_status"

Signed-off-by: Rajendra Dendukuri <rajendra.dendukuri@broadcom.com>