### PR TITLE
[MultiDB] SonicV2Connector class use DBInterface class as member instead of inheritance

### DIFF
--- a/src/swsssdk/dbconnector.py
+++ b/src/swsssdk/dbconnector.py
@@ -223,9 +223,9 @@ class SonicDBConfig(object):
         SonicDBConfig.db_name_validation(db_name, namespace)
         return SonicDBConfig._sonic_db_config[namespace]["DATABASES"][db_name]["separator"]
 
-class SonicV2Connector(DBInterface):
+class SonicV2Connector(object):
     def __init__(self, use_unix_socket_path=False, namespace=None, **kwargs):
-        super(SonicV2Connector, self).__init__(**kwargs)
+        self.dbintf = DBInterface(**kwargs)
         self.use_unix_socket_path = use_unix_socket_path
 
         """If the user don't give the namespace as input, it refers to the local namespace 
@@ -244,19 +244,19 @@ class SonicV2Connector(DBInterface):
 
     def connect(self, db_name, retry_on=True):
         if self.use_unix_socket_path:
-            self.redis_kwargs["unix_socket_path"] = self.get_db_socket(db_name)
-            self.redis_kwargs["host"] = None
-            self.redis_kwargs["port"] = None
+            self.dbintf.redis_kwargs["unix_socket_path"] = self.get_db_socket(db_name)
+            self.dbintf.redis_kwargs["host"] = None
+            self.dbintf.redis_kwargs["port"] = None
         else:
-            self.redis_kwargs["host"] = self.get_db_hostname(db_name)
-            self.redis_kwargs["port"] = self.get_db_port(db_name)
-            self.redis_kwargs["unix_socket_path"] = None
+            self.dbintf.redis_kwargs["host"] = self.get_db_hostname(db_name)
+            self.dbintf.redis_kwargs["port"] = self.get_db_port(db_name)
+            self.dbintf.redis_kwargs["unix_socket_path"] = None
         db_id = self.get_dbid(db_name)
-        super(SonicV2Connector, self).connect(db_id, retry_on)
+        self.dbintf.connect(db_id, retry_on)
 
     def close(self, db_name):
         db_id = self.get_dbid(db_name)
-        super(SonicV2Connector, self).close(db_id)
+        self.dbintf.close(db_id)
 
     def get_db_list(self):
         return SonicDBConfig.get_dblist(self.namespace)
@@ -281,42 +281,42 @@ class SonicV2Connector(DBInterface):
 
     def get_redis_client(self, db_name):
         db_id = self.get_dbid(db_name)
-        return super(SonicV2Connector, self).get_redis_client(db_id)
+        return self.dbintf.get_redis_client(db_id)
 
     def publish(self, db_name, channel, message):
         db_id = self.get_dbid(db_name)
-        return super(SonicV2Connector, self).publish(db_id, channel, message)
+        return self.dbintf.publish(db_id, channel, message)
 
     def expire(self, db_name, key, timeout_sec):
         db_id = self.get_dbid(db_name)
-        return super(SonicV2Connector, self).expire(db_id, key, timeout_sec)
+        return self.dbintf.expire(db_id, key, timeout_sec)
 
     def exists(self, db_name, key):
         db_id = self.get_dbid(db_name)
-        return  super(SonicV2Connector, self).exists(db_id, key)
+        return self.dbintf.exists(db_id, key)
 
     def keys(self, db_name, pattern='*', *args, **kwargs):
         db_id = self.get_dbid(db_name)
-        return super(SonicV2Connector, self).keys(db_id, pattern, *args, **kwargs)
+        return self.dbintf.keys(db_id, pattern, *args, **kwargs)
 
     def get(self, db_name, _hash, key, *args, **kwargs):
         db_id = self.get_dbid(db_name)
-        return super(SonicV2Connector, self).get(db_id, _hash, key, *args, **kwargs)
+        return self.dbintf.get(db_id, _hash, key, *args, **kwargs)
 
     def get_all(self, db_name, _hash, *args, **kwargs):
         db_id = self.get_dbid(db_name)
-        return super(SonicV2Connector, self).get_all(db_id, _hash, *args, **kwargs)
+        return self.dbintf.get_all(db_id, _hash, *args, **kwargs)
 
     def set(self, db_name, _hash, key, val, *args, **kwargs):
         db_id = self.get_dbid(db_name)
-        return super(SonicV2Connector, self).set(db_id, _hash, key, val, *args, **kwargs)
+        return self.dbintf.set(db_id, _hash, key, val, *args, **kwargs)
 
     def delete(self, db_name, key, *args, **kwargs):
         db_id = self.get_dbid(db_name)
-        return super(SonicV2Connector, self).delete(db_id, key, *args, **kwargs)
+        return self.dbintf.delete(db_id, key, *args, **kwargs)
 
     def delete_all_by_pattern(self, db_name, pattern, *args, **kwargs):
         db_id = self.get_dbid(db_name)
-        super(SonicV2Connector, self).delete_all_by_pattern(db_id, pattern, *args, **kwargs)
+        self.dbintf.delete_all_by_pattern(db_id, pattern, *args, **kwargs)
 
     pass


### PR DESCRIPTION
* issue : https://github.com/Azure/sonic-py-swsssdk/issues/72

* the root cause is : SonicV2Connector connect(dbname) calls base class method connect(dbid), while when connection failed and retry, base class try to call self. connect() which is onicV2Connector connect(dbname) since name are the same. It should call its own connect(dbid).

* for multiDB, we use methods from SonicV2Connector instead of DBInterface based on earlier changes

* we should make sure DBInterface class method uses its own methods inside, hence making DBInterface class as a member of SonicV2Connector instead of inheritance

Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com