### PR TITLE
sonic-py-swsssdk: Changes to support SONiC Gearbox Manager

### DIFF
--- a/src/swsssdk/config/database_config.json
+++ b/src/swsssdk/config/database_config.json
@@ -51,6 +51,26 @@
             "id" : 7,
             "separator": "|",
             "instance" : "redis"
+        },
+        "ASIC_DB2" : {
+            "id" : 8,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "COUNTERS_DB2" : {
+            "id" : 9,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "FLEX_COUNTER_DB2" : {
+            "id" : 10,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "STATE_DB2" : {
+            "id" : 11,
+            "separator": "|",
+            "instance" : "redis"
         }
     },
     "VERSION" : "1.0"


### PR DESCRIPTION
* add databases that will be used to represent second switch (gearbox phy) in REDIS

HLD is located at https://github.com/Azure/SONiC/blob/b817a12fd89520d3fd26bbc5897487928e7f6de7/doc/gearbox/gearbox_mgr_design.md

  Signed-off-by: syd.logan@broadcom.com