### PR TITLE
Upgrade redis library to 3.5.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 dependencies = [
-    'redis==2.10.6',
+    'redis==3.5.3',
     'redis-dump-load',
 ]
 


### PR DESCRIPTION
Upgrade outdated redis python library to latest version, which is still supporting python2.