### PR TITLE
[configdb] Remove call to "bgsave" from table update

### DIFF
--- a/src/swsssdk/configdb.py
+++ b/src/swsssdk/configdb.py
@@ -413,7 +413,6 @@ class ConfigDBPipeConnector(ConfigDBConnector):
             for key in table_data:
                 self.__mod_entry(pipe, table_name, key, table_data[key])
         pipe.execute()
-        client.bgsave()
 
     def __get_config(self, client, pipe, data, cursor):
         """Read config data in batches of size REDIS_SCAN_BATCH_SIZE using Redis pipelines


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

After debugging w/ Tamer offline we figured out that https://github.com/Azure/sonic-buildimage/issues/5263 was being caused because of this call to `bgsave`.

Essentially what is happening is that the Config DB is being saved/checkpointed to disk when this `bgsave` is called, so when the virtual switch restarts the `/etc/sonic/config_db.json` is being added to the existing contents of config DB rather than overwriting them.