### PR TITLE
Fix: no need to decode() after redis client scan, so it will work for both python2 and python3

### DIFF
--- a/src/swsssdk/configdb.py
+++ b/src/swsssdk/configdb.py
@@ -413,7 +413,7 @@ class ConfigDBPipeConnector(ConfigDBConnector):
             cur: poition of next item to scan
         """
         cur, keys = client.scan(cursor=cursor, match='*', count=self.REDIS_SCAN_BATCH_SIZE)
-        keys = [key.decode() for key in keys if key != self.INIT_INDICATOR]
+        keys = [key for key in keys if key != self.INIT_INDICATOR]
         for key in keys:
             pipe.hgetall(key)
         records = pipe.execute()


### PR DESCRIPTION
The original code was tested in python2, which convert a str to a unicode str. It is working but not needed.

```python
>>> client.hgetall('QUEUE|Ethernet100|1')
{'scheduler': '[SCHEDULER|scheduler.0]'}
>>> client.hgetall(u'QUEUE|Ethernet100|1')
{'scheduler': '[SCHEDULER|scheduler.0]'}
>>> a = {}
>>> a['b'] = 'c'
>>> a[u'b'] = 'cc'
>>> a
{'b': 'cc'}
```

Tested in DUT
```
Python 3.7.3 (default, Jul 25 2020, 13:03:44)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from swsssdk import SonicV2Connector, ConfigDBConnector
>>> cfg = ConfigDBConnector()
>>> cfg.connect()
>>> cfg.get_config()
{'QUEUE': ...
```

```
Python 2.7.16 (default, Oct 10 2019, 22:02:15)
[GCC 8.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from swsssdk import SonicV2Connector, ConfigDBConnector
>>> cfg = ConfigDBConnector()
>>> cfg.connect()
>>> cfg.get_config()
{u'NTP_SERVER': ...
```