### PR TITLE
Add support for hexists in dbconnector

### DIFF
--- a/src/swsssdk/dbconnector.py
+++ b/src/swsssdk/dbconnector.py
@@ -305,6 +305,9 @@ class SonicV2Connector(object):
     def get(self, db_name, _hash, key, *args, **kwargs):
         return self.dbintf.get(db_name, _hash, key, *args, **kwargs)
 
+    def hexists(self, db_name, _hash, key, *args, **kwargs):
+        return self.dbintf.hexists(db_name, _hash, key, *args, **kwargs)
+
     def get_all(self, db_name, _hash, *args, **kwargs):
         return self.dbintf.get_all(db_name, _hash, *args, **kwargs)
 

--- a/src/swsssdk/interface.py
+++ b/src/swsssdk/interface.py
@@ -298,6 +298,19 @@ class DBInterface(object):
             # redis only supports strings. if any item is set to string 'None', cast it back to the appropriate type.
             return None if val == b'None' else val
 
+
+    @blockable
+    def hexists(self, db_name, _hash, key):
+        """
+        Check if the value of Key %key exists in Hashtable %hash
+        in Database %db_name
+
+        Parameter %blocking indicates whether to wait
+        when the query fails
+        """
+        client = self.redis_clients[db_name]
+        return (client.hexists(_hash, key))
+
     @blockable
     def get_all(self, db_name, _hash):
         """


### PR DESCRIPTION
dbconnector class doesn't support hexists method today. The hexists method is useful in scripts querying redis DB. This PR adds this support.