### PR TITLE
[Ethernet-IB][index] Modified the port_util to support the VoQ Inband …

### DIFF
--- a/src/swsssdk/port_util.py
+++ b/src/swsssdk/port_util.py
@@ -14,7 +14,7 @@ SONIC_ETHERNET_BP_RE_PATTERN = "^Ethernet-BP(\d+)$"
 SONIC_VLAN_RE_PATTERN = "^Vlan(\d+)$"
 SONIC_PORTCHANNEL_RE_PATTERN = "^PortChannel(\d+)$"
 SONIC_MGMT_PORT_RE_PATTERN = "^eth(\d+)$"
-
+SONIC_ETHERNET_IB_RE_PATTERN = "^Ethernet-IB(\d+)$"
 
 class BaseIdx:
     ethernet_base_idx = 1
@@ -22,6 +22,7 @@ class BaseIdx:
     ethernet_bp_base_idx = 9000
     portchannel_base_idx = 1000
     mgmt_port_base_idx = 10000
+    ethernet_ib_base_idx = 11000
 
 def get_index(if_name):
     """
@@ -31,6 +32,7 @@ def get_index(if_name):
     Ethernet_BP N = N + 9000
     PortChannel N = N + 1000
     eth N = N + 10000
+    Ethernet_IB N = N + 11000
     """
     return get_index_from_str(if_name.decode())
 
@@ -43,13 +45,15 @@ def get_index_from_str(if_name):
     Ethernet_BP N = N + 9000
     PortChannel N = N + 1000
     eth N = N + 10000
+    Ethernet_IB N = N + 11000
     """
     patterns = {
         SONIC_ETHERNET_RE_PATTERN: BaseIdx.ethernet_base_idx,
         SONIC_ETHERNET_BP_RE_PATTERN: BaseIdx.ethernet_bp_base_idx,
         SONIC_VLAN_RE_PATTERN: BaseIdx.vlan_interface_base_idx,
         SONIC_PORTCHANNEL_RE_PATTERN: BaseIdx.portchannel_base_idx,
-        SONIC_MGMT_PORT_RE_PATTERN: BaseIdx.mgmt_port_base_idx
+        SONIC_MGMT_PORT_RE_PATTERN: BaseIdx.mgmt_port_base_idx,
+        SONIC_ETHERNET_IB_RE_PATTERN: BaseIdx.ethernet_ib_base_idx
     }
 
     for pattern, baseidx in patterns.items():


### PR DESCRIPTION
Ethernet-IB port is introduced for the VoQ chassis. This requires to define the index of the Ethernet-IB to allow the application to get the index from the port name. Follow the existing design, define the Inband port index base as 11000.