### PR TITLE
[port_util] Fix issue in function get_interface_oid_map

### DIFF
--- a/src/swsssdk/port_util.py
+++ b/src/swsssdk/port_util.py
@@ -66,8 +66,8 @@ def get_interface_oid_map(db, blocking=True):
         Get the Interface names from Counters DB
     """
     db.connect('COUNTERS_DB')
-    if_name_map = db.get_all('COUNTERS_DB', 'COUNTERS_PORT_NAME_MAP', blocking)
-    if_lag_name_map = db.get_all('COUNTERS_DB', 'COUNTERS_LAG_NAME_MAP', blocking)
+    if_name_map = db.get_all('COUNTERS_DB', 'COUNTERS_PORT_NAME_MAP', blocking=blocking)
+    if_lag_name_map = db.get_all('COUNTERS_DB', 'COUNTERS_LAG_NAME_MAP', blocking=blocking)
     if_name_map.update(if_lag_name_map)
 
     if not if_name_map:


### PR DESCRIPTION
Signed-off-by: liora <liora@nvidia.com>

**What I did**
Change argument 'blocking' in call to function get_all() to a keyword argument as it should.

**How I did it**
Add blocking=xxx in function call.

**How to verify it**
This issue is failing the checkers when updating this submodule hash in sonic-buildimage (see https://github.com/Azure/sonic-buildimage/pull/8696). 