### PR TITLE
Add option to suppress warnings when querying Redis

### DIFF
--- a/src/swsssdk/interface.py
+++ b/src/swsssdk/interface.py
@@ -280,7 +280,7 @@ class DBInterface(object):
             return keys
 
     @blockable
-    def get(self, db_name, _hash, key):
+    def get(self, db_name, _hash, key, log_warning=True):
         """
         Retrieve the value of Key %key from Hashtable %hash
         in Database %db_name
@@ -292,7 +292,8 @@ class DBInterface(object):
         val = client.hget(_hash, key)
         if not val:
             message = "Key '{}' field '{}' unavailable in database '{}'".format(_hash, key, db_name)
-            logger.warning(message)
+            if log_warning:
+                logger.warning(message)
             raise UnavailableDataError(message, _hash)
         else:
             # redis only supports strings. if any item is set to string 'None', cast it back to the appropriate type.
@@ -310,7 +311,8 @@ class DBInterface(object):
         table = client.hgetall(_hash)
         if not table:
             message = "Key '{}' unavailable in database '{}'".format(_hash, db_name)
-            logger.warning(message)
+            if log_warning:
+                logger.warning(message)
             raise UnavailableDataError(message, _hash)
         else:
             # redis only supports strings. if any item is set to string 'None', cast it back to the appropriate type.

--- a/src/swsssdk/interface.py
+++ b/src/swsssdk/interface.py
@@ -280,7 +280,7 @@ class DBInterface(object):
             return keys
 
     @blockable
-    def get(self, db_name, _hash, key, log_warning=True):
+    def get(self, db_name, _hash, key, verbose=True):
         """
         Retrieve the value of Key %key from Hashtable %hash
         in Database %db_name
@@ -292,7 +292,7 @@ class DBInterface(object):
         val = client.hget(_hash, key)
         if not val:
             message = "Key '{}' field '{}' unavailable in database '{}'".format(_hash, key, db_name)
-            if log_warning:
+            if verbose:
                 logger.warning(message)
             raise UnavailableDataError(message, _hash)
         else:
@@ -300,7 +300,7 @@ class DBInterface(object):
             return None if val == b'None' else val
 
     @blockable
-    def get_all(self, db_name, _hash, log_warning=True):
+    def get_all(self, db_name, _hash, verbose=True):
         """
         Get Hashtable %hash from DB %db_name
 
@@ -311,7 +311,7 @@ class DBInterface(object):
         table = client.hgetall(_hash)
         if not table:
             message = "Key '{}' unavailable in database '{}'".format(_hash, db_name)
-            if log_warning:
+            if verbose:
                 logger.warning(message)
             raise UnavailableDataError(message, _hash)
         else:

--- a/src/swsssdk/interface.py
+++ b/src/swsssdk/interface.py
@@ -300,7 +300,7 @@ class DBInterface(object):
             return None if val == b'None' else val
 
     @blockable
-    def get_all(self, db_name, _hash):
+    def get_all(self, db_name, _hash, log_warning=True):
         """
         Get Hashtable %hash from DB %db_name
 

--- a/src/swsssdk/interface.py
+++ b/src/swsssdk/interface.py
@@ -40,7 +40,7 @@ def blockable(f):
                 return ret_data
             except UnavailableDataError as e:
                 if blocking:
-                	logger.warning(e.message)
+                    logger.warning(e.message)
                     if db_name in inst.keyspace_notification_channels:
                         result = inst._unavailable_data_handler(db_name, e.data)
                         if result:


### PR DESCRIPTION
In some circumstances calls are made to query the Redis database without checking if a given key (or key/field pair) exists, and with code to handle the case where it does not. For example many show commands query all possible relevant data, without checking if it exists. In these cases it would be useful to be able to prevent warning logs being written for every missing field, and so we add that option in this PR.