### PR TITLE
Changes to Use Redis Unix Socket if the user is  root else default to TCP

### DIFF
--- a/src/swsssdk/dbconnector.py
+++ b/src/swsssdk/dbconnector.py
@@ -244,7 +244,7 @@ class SonicV2Connector(object):
             kwargs['decode_responses'] = True
 
         self.dbintf = DBInterface(**kwargs)
-        self.use_unix_socket_path = use_unix_socket_path
+        self.use_unix_socket_path = True if use_unix_socket_path and os.getuid() == 0 else False
 
         """If the user don't give the namespace as input, it refers to the local namespace
            where this application is run. (It could be a network namespace or linux host namesapce)


### PR DESCRIPTION
What I did:
Changes to Use Redis Unix Socket if the user is root else default to TCP

Why I did:
With the changes in PR:https://github.com/Azure/sonic-buildimage/pull/5289 access to redis unix socket is given to the redis group members. Many of sonic-util commands (especially in multi-asic) case use redis unix socket to connect to DB and thus those comamnd fails without providing sudo. This PR is continuation  of PR: https://github.com/Azure/sonic-buildimage/pull/7002 where we default to use TCP for Redis if user is not root.

How I did:
Without this change `acl-loader update full erspan_acl_rule_del.json --table_name EVERFLOW` is failing if given with sudo. Post this change it is passing.